### PR TITLE
Arregla el overflow de imgs en comments

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -325,6 +325,12 @@
       margin-bottom: $regMargin;
     }
 
+    .report_box, .comments {
+      .image img {
+        max-width: 100%;
+      }
+    }
+
     .starter {
       .avatar {
         float: left;
@@ -332,9 +338,6 @@
       }
       .image {
         padding: 20px 0 0 0;
-        img {
-          max-width: 100%;
-        }
       }
       .name {
         font-size: ms(.5);
@@ -393,7 +396,7 @@
           margin-right: 20px;
         }
         .created_by, .content {
-          padding-left: 60px;
+          padding-left: 93px;
         }
         .created_by {
           font-family: "MuseoSans-700";


### PR DESCRIPTION
Arregla esto:

![Screen Shot 2013-04-22 at 5 58 33 PM](https://f.cloud.github.com/assets/705860/412121/ab9cd802-aba2-11e2-9c56-c23b0f3a1424.png)

Repitiendo la regla de max-width 100% también en la sección de comments
