### PR TITLE
secure secreton token on production

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,8 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-ReporteCiudadano::Application.config.secret_token = 'e1a90e2914f3c9f6049d9ded629ee54e65fd48f4dc9f0e4d9f4ca25253313462220093d2a3e16486e9f926cb3e42d0ffc3fa73b11049bdf5e8215ec8946bce16'
+ReporteCiudadano::Application.config.secret_token = if Rails.env.production?
+  ENV['SECRET_TOKEN']
+else
+  ('x' * 30) # requirimiento minimo de 30 caracteres
+end


### PR DESCRIPTION
http://daniel.fone.net.nz/blog/2013/05/20/a-better-way-to-manage-the-rails-secret-token/
Algo de información de porque no tener 'hard-coded' el secret_token
